### PR TITLE
Fix site inheritance at parent publish

### DIFF
--- a/src/wagtail_site_inheritance/wagtail_hooks.py
+++ b/src/wagtail_site_inheritance/wagtail_hooks.py
@@ -52,9 +52,9 @@ def update_or_create_copies(request, page):
         return
 
     # Mark edited page as modified
-    models.PageInheritanceItem.objects.filter(inherited_page=page, modified=False).update(
-        modified=True
-    )
+    models.PageInheritanceItem.objects.filter(
+        inherited_page=page, modified=False
+    ).update(modified=True)
 
     create_non_existing_pages(request, page, parent_page)
     sync_existing_pages(request, page)

--- a/src/wagtail_site_inheritance/wagtail_hooks.py
+++ b/src/wagtail_site_inheritance/wagtail_hooks.py
@@ -52,7 +52,7 @@ def update_or_create_copies(request, page):
         return
 
     # Mark edited page as modified
-    models.PageInheritanceItem.objects.filter(page=page, modified=False).update(
+    models.PageInheritanceItem.objects.filter(inherited_page=page, modified=False).update(
         modified=True
     )
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,5 +1,8 @@
+import pytest
+
 from tests.fixtures import *
 from tests.testapp.models import HomePage
+from wagtail_site_inheritance.models import PageInheritanceItem
 from wagtail_site_inheritance.wagtail_hooks import update_or_create_copies
 
 
@@ -20,7 +23,27 @@ def test_update_or_create_copies(site_setup, rf):
     # body is inherited, inheriting site should have inherited the value of the main site
     assert main_page.body == "Main site body"
     assert inheriting_page.body == "Main site body"
-
-    # custom content is not inherited, main site value should be different
+    
+    # custom content was only set on the main page, but it is also inherited as the
+    # custom_content field is inherited from the main page
     assert main_page.custom_content == "Main site custom content"
-    assert inheriting_page.custom_content == "Custom content text"
+    assert inheriting_page.custom_content == "Main site custom content"
+
+    assert PageInheritanceItem.objects.first().modified == False
+
+    form_data = {"custom_content": "NEW CONTENT", "action-publish": "action-publish"}
+    req = rf.post(
+        path=f"/cms/pages/{site_setup.inheriting_site.root_page.id}/edit/", data=form_data
+    )
+    req.user.username = 'Dealer'
+    req.user.is_active = True
+    req.user.is_superuser = True
+    req.user.save()
+    update_or_create_copies(req, site_setup.inheriting_site.root_page)
+
+    # We have updated the inherited page, so the modified flag should be set to True
+    assert PageInheritanceItem.objects.first().modified
+
+
+
+

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -23,7 +23,7 @@ def test_update_or_create_copies(site_setup, rf):
     # body is inherited, inheriting site should have inherited the value of the main site
     assert main_page.body == "Main site body"
     assert inheriting_page.body == "Main site body"
-    
+
     # custom content was only set on the main page, but it is also inherited as the
     # custom_content field is inherited from the main page
     assert main_page.custom_content == "Main site custom content"
@@ -33,9 +33,10 @@ def test_update_or_create_copies(site_setup, rf):
 
     form_data = {"custom_content": "NEW CONTENT", "action-publish": "action-publish"}
     req = rf.post(
-        path=f"/cms/pages/{site_setup.inheriting_site.root_page.id}/edit/", data=form_data
+        path=f"/cms/pages/{site_setup.inheriting_site.root_page.id}/edit/",
+        data=form_data,
     )
-    req.user.username = 'Dealer'
+    req.user.username = "Dealer"
     req.user.is_active = True
     req.user.is_superuser = True
     req.user.save()
@@ -43,7 +44,3 @@ def test_update_or_create_copies(site_setup, rf):
 
     # We have updated the inherited page, so the modified flag should be set to True
     assert PageInheritanceItem.objects.first().modified
-
-
-
-

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from wagtail import VERSION as wagtail_version
 
-from wagtail_site_inheritance.models import PageInheritanceMixin
+from wagtail_site_inheritance.models import PageInheritanceItem, PageInheritanceMixin
 
 if wagtail_version >= (3, 0):
     from wagtail.models import Page
@@ -13,3 +13,28 @@ class HomePage(PageInheritanceMixin, Page):
     body = models.CharField(max_length=500, default="")
     custom_content = models.CharField(max_length=500, default="")
     inherit_readonly_fields = ["body"]
+
+    def full_clean(self, *args, **kwargs):
+        """Apply fixups that need to happen before per-field validation occurs.
+
+        Overridden to ensure translation keys remain consistent with inherited pages.
+        If there's a mismatch, we ensure this is logged and automatically correct it.
+        """
+        is_new = self.pk is None
+        if not is_new:
+            try:
+                item = PageInheritanceItem.objects.get(inherited_page=self)
+                if (
+                    not self.translation_key  # type: ignore
+                    == item.inherited_page.translation_key
+                ):
+                    self.translation_key = item.inherited_page.translation_key
+                if not self.locale_id == item.inherited_page.locale_id:
+                    self.locale = item.inherited_page.locale
+            except PageInheritanceItem.DoesNotExist:
+                # All good. No inheritance item exists (yet), so we don't have to
+                # check if the translation key is correct.
+                pass
+
+        super().full_clean(*args, **kwargs)
+

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -37,4 +37,3 @@ class HomePage(PageInheritanceMixin, Page):
                 pass
 
         super().full_clean(*args, **kwargs)
-


### PR DESCRIPTION
During the last deployment a bug was introduced that caused the inherited pages to be marked as modified when the parent page was edited and published.